### PR TITLE
more compact and informative logging by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,15 @@ version = "0.1.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SKFR = "a6138be3-5d3e-4f3e-9009-7e37efc59f36"
 SnpArrays = "4e780e97-f5bf-4111-9dc4-b70aaf691b06"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
 Adapt = "3.3"

--- a/src/OpenADMIXTURE.jl
+++ b/src/OpenADMIXTURE.jl
@@ -6,6 +6,7 @@ using Base.Threads
 using SKFR
 export AdmixData
 using Requires, Adapt
+using ProgressMeter, Suppressor, Formatting
 function __init__()
     @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
         using .CUDA


### PR DESCRIPTION
I've made some changes that make the logging output more informative to me as an end user as well as less cluttered. Similar behavior to the original can be enabled by setting `verbose` to true in the function arguments. The proposed new default output is as follows:

```
julia> d, clusters, aims = OpenADMIXTURE.run_admixture(filename, 4; T=Float64, use_gpu=false, rng=MersenneTwister(7856));
Performing 5 EM steps for priming
EM Iteration 1 (0.152715371 sec): Loglikelihood = -1.6585565266198235e7
EM Iteration 2 (0.184933523 sec): Loglikelihood = -1.6007521238366533e7
EM Iteration 3 (0.142413634 sec): Loglikelihood = -1.5916445495428987e7
EM Iteration 4 (0.175262876 sec): Loglikelihood = -1.587417626747727e7
EM Iteration 5 (0.158595219 sec): Loglikelihood = -1.5844784297993343e7
initial ll: -1.5844784297993343e7
Starting main algorithm
Iteration 1 (14.293972724 sec): LogLikelihood = -1.5661966737375751e7, reldiff = 0.011538027730724302
    LogLikelihoods: Previous = -1.5844784297993343e7, QN = -1.5661966737375751e7, Basic = -1.5658797780233778e7
Iteration 2 (10.456170418 sec): LogLikelihood = -1.5605199791986194e7, reldiff = 0.0036245093825980914
    LogLikelihoods: Previous = -1.5661966737375751e7, QN = -1.5605199791986194e7, Basic = -1.5609040036582384e7
Iteration 3 (9.546737437 sec): LogLikelihood = -1.5586228372093504e7, reldiff = 0.0012157114388520478
    LogLikelihoods: Previous = -1.5605199791986194e7, QN = -1.5586228372093504e7, Basic = -1.558989311248903e7
Iteration 4 (9.245080639 sec): LogLikelihood = -1.557902813062439e7, reldiff = 0.00046196175862575915
    LogLikelihoods: Previous = -1.5586228372093504e7, QN = -1.557902813062439e7, Basic = -1.557593892598145e7
Iteration 5 (9.110568684 sec): LogLikelihood = -1.5567066087137524e7, reldiff = 0.0007678298919912029
    LogLikelihoods: Previous = -1.557902813062439e7, QN = -1.5567066087137524e7, Basic = -1.5566929427850641e7
Iteration 6 (9.327391913 sec): LogLikelihood = -1.5561476004841125e7, reldiff = 0.000359096715149059
    LogLikelihoods: Previous = -1.5567066087137524e7, QN = -1.5561476004841125e7, Basic = -1.556264024120358e7
Iteration 7 (10.00942772 sec): LogLikelihood = -1.5558616674667932e7, reldiff = 0.00018374414948190118
    LogLikelihoods: Previous = -1.5561476004841125e7, QN = -1.5558616674667932e7, Basic = -1.5558483191215409e7
Iteration 8 (10.512415633 sec): LogLikelihood = -1.5556607054798864e7, reldiff = 0.00012916443094457538
    LogLikelihoods: Previous = -1.5558616674667932e7, QN = -1.5556607054798864e7, Basic = -1.555656394773972e7
Iteration 9 (9.690703713 sec): LogLikelihood = -1.5555028877712639e7, reldiff = 0.00010144738378141057
    LogLikelihoods: Previous = -1.5556607054798864e7, QN = -1.5555028877712639e7, Basic = -1.5555272556777712e7
Iteration 10 (9.594756342 sec): LogLikelihood = -1.5554389948288705e7, reldiff = 4.107542512179528e-5
    LogLikelihoods: Previous = -1.5555028877712639e7, QN = -1.5572307162296195e7, Basic = -1.5554389948288705e7
Iteration 11 (9.39072147 sec): LogLikelihood = -1.5553867013950767e7, reldiff = 3.361972662873465e-5
    LogLikelihoods: Previous = -1.5554389948288705e7, QN = -1.5562818039977925e7, Basic = -1.5553867013950767e7
Iteration 12 (8.895711263 sec): LogLikelihood = -1.5553428107705034e7, reldiff = 2.8218464600411636e-5
    LogLikelihoods: Previous = -1.5553867013950767e7, QN = -1.5559131012878079e7, Basic = -1.5553428107705034e7
Iteration 13 (9.072996228 sec): LogLikelihood = -1.5553067050573548e7, reldiff = 2.3213990445434272e-5
    LogLikelihoods: Previous = -1.5553428107705034e7, QN = -1.5554525394768834e7, Basic = -1.5553067050573548e7
Iteration 14 (9.523288256 sec): LogLikelihood = -1.555278497410975e7, reldiff = 1.8136388332978923e-5
    LogLikelihoods: Previous = -1.5553067050573548e7, QN = -1.5553105606121972e7, Basic = -1.555278497410975e7
Iteration 15 (9.298866998 sec): LogLikelihood = -1.5552639211087858e7, reldiff = 9.372149241089872e-6
    LogLikelihoods: Previous = -1.555278497410975e7, QN = -1.5552639211087858e7, Basic = -1.5552595414835572e7
Iteration 16 (8.900257679 sec): LogLikelihood = -1.5552328125458859e7, reldiff = 2.000211184591851e-5
    LogLikelihoods: Previous = -1.5552639211087858e7, QN = -1.5552328125458859e7, Basic = -1.5552311626407882e7
Iteration 17 (8.672770113 sec): LogLikelihood = -1.5552259885576095e7, reldiff = 4.387759968346335e-6
    LogLikelihoods: Previous = -1.5552328125458859e7, QN = -1.5552259885576095e7, Basic = -1.5552266154130427e7
Iteration 18 (8.736132223 sec): LogLikelihood = -1.5552230063723285e7, reldiff = 1.917525364808176e-6
    LogLikelihoods: Previous = -1.5552259885576095e7, QN = -1.5552230063723285e7, Basic = -1.5552235725528445e7
Iteration 19 (8.653978879 sec): LogLikelihood = -1.5552216346354242e7, reldiff = 8.820194265473032e-7
    LogLikelihoods: Previous = -1.5552230063723285e7, QN = -1.5552216346354242e7, Basic = -1.555222164931152e7
Iteration 20 (8.722446271 sec): LogLikelihood = -1.5552207512250777e7, reldiff = 5.680285863018589e-7
    LogLikelihoods: Previous = -1.5552216346354242e7, QN = -1.5552207512250777e7, Basic = -1.5552210406862404e7
Iteration 21 (8.746605755 sec): LogLikelihood = -1.5552200611477997e7, reldiff = 4.437166090244169e-7
    LogLikelihoods: Previous = -1.5552207512250777e7, QN = -1.5552200611477997e7, Basic = -1.5552204951377708e7
Iteration 22 (8.630398232 sec): LogLikelihood = -1.5552197336867832e7, reldiff = 2.1055606517124269e-7
    LogLikelihoods: Previous = -1.5552200611477997e7, QN = -1.5552197336867832e7, Basic = -1.5552198775938418e7
Iteration 23 (8.730630149 sec): LogLikelihood = -1.5552194868097581e7, reldiff = 1.587409288349003e-7
    LogLikelihoods: Previous = -1.5552197336867832e7, QN = -1.5552194868097581e7, Basic = -1.5552196340740334e7
Iteration 24 (9.131821986 sec): LogLikelihood = -1.5552193929721253e7, reldiff = 6.033722802055984e-8
    LogLikelihoods: Previous = -1.5552194868097581e7, QN = -1.5552193929721253e7, Basic = -1.5552194288014418e7
Main algorithm converged in 24 iterations over 226.900157842 sec.
```

I am also working on a command-line interface and docker/singularity container at [BEFH/docker_OpenADMIXTURE](https://github.com/BEFH/docker_OpenADMIXTURE), but it's not ready yet for prime-time.